### PR TITLE
Don't assume default locale

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ function txApp(modules) {
 
     // Do Async!!!!
     // Queue async calls and set callback page init
-    this.uiArticlesTab();
+    this.uiLoadConf();
   }
 
   // Check for completion of asynchronous operation

--- a/src/lib/ui/sync-factory.js
+++ b/src/lib/ui/sync-factory.js
@@ -95,6 +95,21 @@ module.exports = function(T, t, api) {
       'ui<T>Tab': function(event) {
         if (event) event.preventDefault();
         if (this.processing) return;
+        if (io.getPageError()) {
+          this.switchTo('loading_page', {
+            page: t,
+            page_articles: t == 'articles',
+            page_categories: t == 'categories',
+            page_sections: t == 'sections',
+            error: true,
+            login_error: io.getPageError().split(':')[1] === 'login',
+            locale_error: io.getPageError().split(':')[1] === 'locale',
+            project_error: io.getPageError().split(':')[1] === 'not_found',
+            transifex_error: io.getPageError().split(':')[0] === 'txProject',
+            zendesk_error: io.getPageError().split(':')[0] === 'zdSync',
+          });
+          return;
+        }
         factory.currentpage = '1';
         var sorting = io.getSorting();
         sorting.sortby = 'title';
@@ -106,20 +121,6 @@ module.exports = function(T, t, api) {
         if (event) event.preventDefault();
         logger.debug(M('ui<T>Init'));
 
-        if (io.getPageError()) {
-          this.switchTo('loading_page', {
-            page: t,
-            page_articles: t == 'articles',
-            page_categories: t == 'categories',
-            page_sections: t == 'sections',
-            error: true,
-            login_error: io.getPageError().split(':')[1] === 'login',
-            project_error: io.getPageError().split(':')[1] === 'not_found',
-            transifex_error: io.getPageError().split(':')[0] === 'txProject',
-            zendesk_error: io.getPageError().split(':')[0] === 'zdSync',
-          });
-          return;
-        }
         var pageData = this[M('buildSyncPage<T>Data')]();
         this.switchTo('sync_page', {
           page: t,

--- a/src/lib/ui/sync-factory.js
+++ b/src/lib/ui/sync-factory.js
@@ -40,6 +40,14 @@ module.exports = function(T, t, api) {
       'click .js-<t>.js-select-all': M('ui<T>SelectAll'),
     },
     eventHandlers: {
+      'uiLoadConf': function(event) {
+        if (event) event.preventDefault();
+        if (this.processing) return;
+        this.loadSyncPage = this.uiArticlesTab;
+        this.asyncGetActivatedLocales();
+        this.asyncGetCurrentLocale();
+        this.asyncGetTxProject();
+      },
       'ui<T>SelectAll': function(event) {
         if (this.processing) return;
         if (this.$(event.target).is(':checked')) {
@@ -212,8 +220,6 @@ module.exports = function(T, t, api) {
 
         var sorting = io.getSorting();
         io.setPageError(null);
-        this.asyncGetActivatedLocales();
-        this.asyncGetTxProject();
         this[M('asyncGetZd<T>Full')](
           factory.currentpage, sorting.sortby,
           sorting.sortdirection, sorting.perpage

--- a/src/lib/zendesk-api/config.js
+++ b/src/lib/zendesk-api/config.js
@@ -9,8 +9,8 @@ var config = module.exports = {
   events: {
     'activatedLocales.done': 'activatedLocalesDone',
     'activatedLocales.fail': 'activatedLocalesFail',
-    'currentLocale.done': 'currentLocaleDone',
-    'currentLocale.fail': 'currentLocaleFail',
+    'defaultLocale.done': 'defaultLocaleDone',
+    'defaultLocale.fail': 'defaultLocaleFail',
   },
   requests: {
     activatedLocales: function() {
@@ -21,10 +21,10 @@ var config = module.exports = {
         dataType: 'json',
       };
     },
-    currentLocale: function() {
+    defaultLocale: function() {
       logger.debug('Retrieving activated locales for account');
       return {
-        url: config.base_url + 'locales/current.json',
+        url: config.base_url + 'locales.json',
         type: 'GET',
         dataType: 'json',
       };
@@ -41,15 +41,18 @@ var config = module.exports = {
       io.popSync(config.key + 'activated');
       this.checkAsyncComplete();
     },
-    currentLocaleDone: function(data, textStatus, jqXHR) {
+    defaultLocaleDone: function(data, textStatus, jqXHR) {
       logger.info('Activated Locales Retrieved with status:', textStatus);
-      this.store('current_locale', data.locale.locale.toLowerCase());
-      io.popSync(config.key + 'current');
+      var locale = _.find(data['locales'], function(l){
+        return l.default;
+      });
+      this.store('default_locale', locale.locale.toLowerCase());
+      io.popSync(config.key + 'default');
       this.checkAsyncComplete();
     },
-    currentLocaleFail: function(jqXHR, textStatus) {
+    defaultLocaleFail: function(jqXHR, textStatus) {
       logger.info('Locales Retrieved with status:', textStatus);
-      io.popSync(config.key + 'current');
+      io.popSync(config.key + 'default');
       io.setPageError('zdLocales');
       this.checkAsyncComplete();
     },
@@ -66,8 +69,8 @@ var config = module.exports = {
       this.ajax('activatedLocales');
     },
     asyncGetCurrentLocale: function() {
-      io.pushSync(config.key + 'current');
-      this.ajax('currentLocale');
+      io.pushSync(config.key + 'default');
+      this.ajax('defaultLocale');
     },
   }
 };

--- a/src/lib/zendesk-api/config.js
+++ b/src/lib/zendesk-api/config.js
@@ -8,13 +8,23 @@ var config = module.exports = {
   key: 'zd_config',
   events: {
     'activatedLocales.done': 'activatedLocalesDone',
-    'activatedLocales.fail': 'activatedLocalesFail'
+    'activatedLocales.fail': 'activatedLocalesFail',
+    'currentLocale.done': 'currentLocaleDone',
+    'currentLocale.fail': 'currentLocaleFail',
   },
   requests: {
     activatedLocales: function() {
       logger.debug('Retrieving activated locales for account');
       return {
         url: config.base_url + 'locales/public.json',
+        type: 'GET',
+        dataType: 'json',
+      };
+    },
+    currentLocale: function() {
+      logger.debug('Retrieving activated locales for account');
+      return {
+        url: config.base_url + 'locales/current.json',
         type: 'GET',
         dataType: 'json',
       };
@@ -28,20 +38,36 @@ var config = module.exports = {
         locales.push(l['locale'].toLowerCase());
       });
       this.store('zd_project_locales', locales);
-      io.popSync(config.key);
+      io.popSync(config.key + 'activated');
+      this.checkAsyncComplete();
+    },
+    currentLocaleDone: function(data, textStatus, jqXHR) {
+      logger.info('Activated Locales Retrieved with status:', textStatus);
+      this.store('current_locale', data.locale.locale.toLowerCase());
+      io.popSync(config.key + 'current');
+      this.checkAsyncComplete();
+    },
+    currentLocaleFail: function(jqXHR, textStatus) {
+      logger.info('Locales Retrieved with status:', textStatus);
+      io.popSync(config.key + 'current');
+      io.setPageError('zdLocales');
       this.checkAsyncComplete();
     },
     activatedLocalesFail: function(jqXHR, textStatus) {
-      logger.info('Activated Locales Retrieved with status:', textStatus);
-      io.popSync(config.key);
+      logger.info('Locales Retrieved with status:', textStatus);
+      io.popSync(config.key + 'activated');
       io.setPageError('zdLocales');
       this.checkAsyncComplete();
     },
   },
   actionHandlers: {
     asyncGetActivatedLocales: function() {
-      io.pushSync(config.key);
+      io.pushSync(config.key + 'activated');
       this.ajax('activatedLocales');
+    },
+    asyncGetCurrentLocale: function() {
+      io.pushSync(config.key + 'current');
+      this.ajax('currentLocale');
     },
   }
 };

--- a/src/lib/zendesk-api/factory.js
+++ b/src/lib/zendesk-api/factory.js
@@ -29,7 +29,7 @@ module.exports = function(name, key, api) {
     },
     requests: {
       'zd<T>Full': function(page, sortby, sortdirection, numperpage) {
-        var locale = this.store('current_locale');
+        var locale = this.store('default_locale');
         var numberperpageString = "";
         if (numperpage) {
           numberperpageString = "?per_page=" + numperpage;

--- a/src/lib/zendesk-api/factory.js
+++ b/src/lib/zendesk-api/factory.js
@@ -29,6 +29,7 @@ module.exports = function(name, key, api) {
     },
     requests: {
       'zd<T>Full': function(page, sortby, sortdirection, numperpage) {
+        var locale = this.store('current_locale');
         var numberperpageString = "";
         if (numperpage) {
           numberperpageString = "?per_page=" + numperpage;
@@ -59,7 +60,7 @@ module.exports = function(name, key, api) {
           sortdirectionString = '&sort_order=' + sortdirection;
         }
         return {
-          url: factory.base_url + 'en-us/' + api + '.json' + numberperpageString +
+          url: factory.base_url + locale + '/' +  api + '.json' + numberperpageString +
             pageString + sortbyString + sortdirectionString,
           type: 'GET',
           dataType: 'json'

--- a/src/templates/loading_page.hdbs
+++ b/src/templates/loading_page.hdbs
@@ -107,8 +107,12 @@
             We were unable to find the Transifex project (<a href="{{setting "tx_project"}}" class="o-link">{{setting "tx_project"}}</a>) associated with Transifex Sync.<br>
             Please make sure the project URL in the Transifex <a href="/agent/admin/apps/manage" class="o-link">App Configuration</a> is correct.
             {{else}}
-            We could not reach the Transifex servers.<br>
-            Please <a href="#" class="o-link js-{{page}} js-refresh">refresh</a> to try again.
+              {{#if locale_error}}
+              Source language of Transifex project does not match the default language of your Zendesk Account.
+              {{else}}
+              We could not reach the Transifex servers.<br>
+              Please <a href="#" class="o-link js-{{page}} js-refresh">refresh</a> to try again.
+              {{/if}}
             {{/if}}
           {{/if}}
         {{/if}}


### PR DESCRIPTION
@nbasili with this PR we use the default locale of the zendesk account (previously assuming en-us) for the endpoints that load Articles/Section/Resources. Also added an extra check so that the source language of the Transifex project and the default language of the ZD account match. Can you pls review?