### PR TITLE
Locales mapping

### DIFF
--- a/src/lib/io.js
+++ b/src/lib/io.js
@@ -83,7 +83,9 @@ module.exports = {
     return OP;
   },
   getLocales: function() {
-    return ZD_LOCALES;
+    return _.map(ZD_LOCALES, function(l){
+      return l['locale'].toLowerCase();
+    });
   },
   setLocales: function(locales) {
     ZD_LOCALES = locales;

--- a/src/lib/syncUtil.js
+++ b/src/lib/syncUtil.js
@@ -44,10 +44,10 @@ module.exports = {
       return l;
 
     // match de_DE like codes to de
-    if (l.indexOf('_') !== -1) {
-      l = l.split('_');
+    if (l.indexOf('-') !== -1) {
+      l = l.split('-');
       if (l[0] == l[1] && _.contains(zd_locales, l[0]))
-        return l;
+        return l[0];
     }
     return null;
   },

--- a/src/lib/syncUtil.js
+++ b/src/lib/syncUtil.js
@@ -23,11 +23,20 @@ module.exports = {
     return c;
   },
 
-  txLocaletoZd: function(l) {
+  txLocaletoZd: function(l, zd_locales) {
     l = l.toLowerCase().replace('_', '-');
+    if (_.contains(zd_locales, l))
+      return l;
     // match TX locale 'en' always to ZD 'en-us'
-    if (l === 'en') l = 'en-us';
-    return l;
+    if (l === 'en') {
+      l = 'en-us';
+      return l;
+    }
+    // match de_DE like codes to de
+    l = l.split('_');
+    if (l[0] == l[1] && _.contains(zd_locales, l[0]))
+      return l;
+    return null;
   },
 
   isStringinArray: function(s, arr) {

--- a/src/lib/syncUtil.js
+++ b/src/lib/syncUtil.js
@@ -24,18 +24,33 @@ module.exports = {
   },
 
   txLocaletoZd: function(l, zd_locales) {
+    var mappings = {
+      en: 'en-us',
+      ko_KR: 'ko',
+      ja_JP: 'ja',
+      bs_BA: 'ba',
+      da_DK: 'da',
+      el_GR: 'el',
+      et_EE: 'et',
+      ka_GE: 'ka',
+      ms_MY: 'ms',
+      sv_SE: 'sv',
+      uk_UA: 'uk',
+      vi_VN: 'vi',
+    };
+    if (mappings[l] !== undefined)
+      return mappings[l];
+
     l = l.toLowerCase().replace('_', '-');
     if (_.contains(zd_locales, l))
       return l;
-    // match TX locale 'en' always to ZD 'en-us'
-    if (l === 'en') {
-      l = 'en-us';
-      return l;
-    }
+
     // match de_DE like codes to de
-    l = l.split('_');
-    if (l[0] == l[1] && _.contains(zd_locales, l[0]))
-      return l;
+    if (l.indexOf('_') !== -1) {
+      l = l.split('_');
+      if (l[0] == l[1] && _.contains(zd_locales, l[0]))
+        return l;
+    }
     return null;
   },
 

--- a/src/lib/syncUtil.js
+++ b/src/lib/syncUtil.js
@@ -3,8 +3,6 @@
  * @module syncUtil
  */
 
-var io = require('io');
-
 module.exports = {
   resources: {
     PATTERN: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,

--- a/src/lib/transifex-api/resource.js
+++ b/src/lib/transifex-api/resource.js
@@ -168,16 +168,12 @@ var resource = module.exports = {
   actionHandlers: {
     completedLanguages: function(stats) {
       var arr = [],
-          zd_enabled = [],
           locales = io.getLocales(),
           default_locale = this.store('default_locale');
-      _.map(locales, function(l){
-        zd_enabled.push(l['locale'].toLowerCase());
-      });
       _.each(stats, function(value, key) {
         var match = (value['completed'] === "100%");
-        var zd_key = syncUtil.txLocaletoZd(key);
-        if (match && zd_enabled.indexOf(zd_key) != -1 && zd_key !== default_locale) {
+        var zd_key = syncUtil.txLocaletoZd(key, locales);
+        if (match && zd_key && zd_key !== default_locale) {
           arr.push(key);
         }
       });
@@ -217,12 +213,9 @@ var resource = module.exports = {
   helpers: {
     resourceCompletedPercentage: function(resource_stats) {
       var sum = 0, locale_count = 0,
-          supported_locales = io.getLocales();
-      supported_locales = _.map(supported_locales, function(l){
-        return l['locale'].toLowerCase();
-      });
+          locales = io.getLocales();
       _.each(resource_stats, function(stat, code) {
-        if (_.contains(supported_locales, syncUtil.txLocaletoZd(code))) {
+        if (syncUtil.txLocaletoZd(code, locales) !== null) {
           sum += parseInt(stat.completed.split('%')[0]);
           locale_count += 1;
         }

--- a/src/lib/ui/sync-factory.js
+++ b/src/lib/ui/sync-factory.js
@@ -206,11 +206,7 @@ module.exports = function(T, t, api) {
           category = api[0].toUpperCase() + api.slice(1);
 
         var objects = _.filter(obj[m('<t>')], function(o){
-          for (var i = 0; i < object_ids.length; i++) {
-            if (o.resource_name == object_ids[i])
-              return true;
-          }
-          return false;
+          return object_ids.indexOf(o.resource_name) !== -1;
         });
         if (!objects.length) return;
         this[M('start<T>Process')]('upload');
@@ -238,19 +234,16 @@ module.exports = function(T, t, api) {
             data = this.store(zdApi.key),
             obj = this[M('calcResourceName<T>')](data),
             entry, resource, txResourceName, completedLocales,
-            zdLocale, translation;
+            zdLocale, translation, zd_locales;
 
         var objects = _.filter(obj[m('<t>')], function(o){
-          for (var i = 0; i < object_ids.length; i++) {
-            if (o.resource_name == object_ids[i])
-              return true;
-          }
-          return false;
+          return object_ids.indexOf(o.resource_name) !== -1;
         });
         this[M('start<T>Process')]('download');
         io.opResetAll();
         this.loadSyncPage = this[M('ui<T>DownloadComplete')];
 
+        zd_locales = io.getLocales();
         for (var i = 0; i < objects.length; i++) {
           entry = objects[i];
           txResourceName = entry.resource_name;
@@ -258,12 +251,10 @@ module.exports = function(T, t, api) {
           completedLocales = this.completedLanguages(resource);
 
           for (var ii = 0; ii < completedLocales.length; ii++) { // iterate through list of locales
-            if (sourceLocale !== completedLocales[ii]) { // skip the source locale
-              translation = this.store(txResource.key + txResourceName + completedLocales[ii]);
-              if (typeof translation.content === 'string') {
-                zdLocale = syncUtil.txLocaletoZd(completedLocales[ii]);
-                this[M('zdUpsert<T>Translation')](translation.content, entry, zdLocale);
-              }
+            translation = this.store(txResource.key + txResourceName + completedLocales[ii]);
+            if (typeof translation.content === 'string') {
+              zdLocale = syncUtil.txLocaletoZd(completedLocales[ii], zd_locales);
+              this[M('zdUpsert<T>Translation')](translation.content, entry, zdLocale);
             }
           }
         }

--- a/test/unit/01.txproject.spec.js
+++ b/test/unit/01.txproject.spec.js
@@ -55,14 +55,14 @@ describe('A function getSourceLocale', () => {
 describe('A function getLocales', () => {
   let testJson
   before(function() {
-    testJson = mockProjectJsonResponse();
+    testJson = mockZDLocalesJsonResponse();
   })
   it('should exist ', () => {
     expect(io.getLocales).to.not.be.undefined;
   });
-  it('should return an object ', () => {
+  it('should return an array', () => {
     io.setLocales(testJson);
-    expect(io.getLocales(testJson)).to.be.a('object')
+    expect(io.getLocales()).to.be.a('Array')
   });
 });
 
@@ -160,4 +160,30 @@ function mockProjectJsonResponse() {
     },],
     name: 'txtest',
   };
+}
+
+function mockZDLocalesJsonResponse() {
+  return [{
+    'url':'https://txtest.zendesk.com/api/v2/locales/en-US.json',
+    'id':1,
+    'locale':'en-US',
+    'name':'English',
+    'native_name':'English',
+    'presentation_name':'English',
+    'rtl':false,
+    'created_at':null,
+    'updated_at':'2017-01-27T23:03:43Z',
+    'default':true
+  }, {
+    'url':'https://txtest.zendesk.com/api/v2/locales/es.json',
+    'id':2,
+    'locale':'es',
+    'name':'Español',
+    'native_name':'español',
+    'presentation_name':'Spanish - español',
+    'rtl':false,
+    'created_at':'2009-02-07T15:08:57Z',
+    'updated_at':'2017-01-27T23:37:02Z',
+    'default':false
+  }];
 }


### PR DESCRIPTION
@alexpsi with this PR we improve the way we map TX locales to ZD. In essence now locales like de_DE or ko_KR that don't exist in ZD are mapped to their two letter language code, in these cases to `de` and `ko` respectively. Pls review and merge!