### PR TITLE
Local storage usage

### DIFF
--- a/src/lib/ui/sync-factory.js
+++ b/src/lib/ui/sync-factory.js
@@ -28,8 +28,6 @@ module.exports = function(T, t, api) {
     events: {
       'click [tab="<t>"]': M('ui<T>Tab'),
       'click .js-<t>.js-goto-page': M('ui<T>GotoPage'),
-      'click .js-<t>.js-goto-next': M('ui<T>NextPage'),
-      'click .js-<t>.js-goto-prev': M('ui<T>PrevPage'),
       'click .js-<t>.js-sortby-title': M('ui<T>SortByTitle'),
       'click .js-<t>.js-sortby-updated_at': M('ui<T>SortByUpdated'),
       'click .js-<t>[perpage]': M('ui<T>PerPage'),
@@ -517,31 +515,28 @@ module.exports = function(T, t, api) {
         this.loadSyncPage = this[M('ui<T>LanguageComplete')];
         this[M('syncCompletedLanguages<T>')]();
       },
+
       'ui<T>LanguageComplete': function() {
         logger.debug(M('ui<T>LanguageComplete'));
+
         var data = this[M('calcResourceName<T>')](this.store(zdApi.key)),
-            num = data[t].length,
             numLanguages = 0,
             resourceName = '',
-            resource = {},
-            languageArray = [],
-            resourceLanguage = {};
-        for (var i = 0; i < num; i++) {
+            resource = {};
+
+        for (var i = 0; i < data[t].length; i++) {
           resourceName = data[t][i].resource_name;
           resource = this.store(txResource.key + resourceName);
           //TODO depends on resource typeness
           if (typeof resource !== 'number') {
-            languageArray = this.completedLanguages(resource);
-            numLanguages = languageArray.length;
-            for (var ii = 0; ii < numLanguages; ii++) {
-              resourceLanguage = this.store(txResource.key + resourceName + languageArray[ii]);
-              if (resourceLanguage) {
-                this.$('#' + resourceName).addClass('js-can-download');
-              }
+            numLanguages = this.completedLanguages(resource).length;
+            if (numLanguages) {
+              this.$('#' + resourceName).addClass('js-can-download');
             }
           }
         }
       },
+
       'ui<T>GotoPage': function(event) {
         if (event) event.preventDefault();
         if (this.processing) return;
@@ -565,54 +560,7 @@ module.exports = function(T, t, api) {
         });
         this.loadSyncPage = this[M('ui<T>Init')];
       },
-      'ui<T>NextPage': function(event) {
-        if (event) event.preventDefault();
-        if (this.processing) return;
 
-        logger.debug(M('ui<T>NextPage'));
-        var page = this.$(event.target).attr("data-current-page"),
-            nextPage = parseInt(page, 10) + 1,
-            sorting = io.getSorting(),
-            query = io.getQuery();
-        factory.currentpage = nextPage;
-        this[M('asyncGetZd<T>Full')](
-          factory.currentpage, sorting.sortby,
-          sorting.sortdirection, sorting.perpage, query
-        );
-        this.switchTo('loading_page', {
-          page: t,
-          page_articles: t == 'articles',
-          page_categories: t == 'categories',
-          page_sections: t == 'sections',
-          page_dynamic_content: t == 'dynamic',
-          query_term: query,
-        });
-        this.loadSyncPage = this[M('ui<T>Init')];
-      },
-      'ui<T>PrevPage': function(event) {
-        if (event) event.preventDefault();
-        if (this.processing) return;
-
-        logger.debug(M('ui<T>PrevPage'));
-        var page = this.$(event.target).attr("data-current-page"),
-            prevPage = parseInt(page, 10) - 1,
-            sorting = io.getSorting(),
-            query = io.getQuery();
-        factory.currentpage = prevPage;
-        this[M('asyncGetZd<T>Full')](
-          factory.currentpage, sorting.sortby,
-          sorting.sortdirection, sorting.perpage, query
-        );
-        this.switchTo('loading_page', {
-          page: t,
-          page_articles: t == 'articles',
-          page_categories: t == 'categories',
-          page_sections: t == 'sections',
-          page_dynamic_content: t == 'dynamic',
-          query_term: query,
-        });
-        this.loadSyncPage = this[M('ui<T>Init')];
-      },
       'ui<T>BrandTab': function(event) {
         var brand;
         if (event && event.preventDefault) {
@@ -798,7 +746,9 @@ module.exports = function(T, t, api) {
           ret = _.extend(ret, {
             page_prev_enabled: this.isFewer(data, currentPage),
             page_next_enabled: this.isMore(data, currentPage),
-            current_page: this.getCurrentPage(data),
+            current_page: currentPage,
+            prev_page: currentPage - 1,
+            next_page: currentPage + 1,
             pagination_visible: paginationVisible,
             pages: this.getPages(data)
           });

--- a/src/lib/zendesk-api/dynamic-content.js
+++ b/src/lib/zendesk-api/dynamic-content.js
@@ -141,12 +141,12 @@ var dynamic_content = module.exports = {
     },
   },
   actionHandlers: {
-    zdUpsertDynamicContentTranslation: function(resource_data, entry, zd_locale) {
-      logger.info('Upsert Dynamic Content with Id:' + entry.id + 'and locale:' + zd_locale);
+    zdUpsertDynamicContentTranslation: function(resource_data, entryid, zd_locale) {
+      logger.info('Upsert Dynamic Content with Id:' + entryid + 'and locale:' + zd_locale);
 
       var data, variant, locale_id,
           translation_data = common.translationObjectFormat(this.$, resource_data, zd_locale),
-          existing_locales = this.store(dynamic_content.key + entry.id + '_locales');
+          existing_locales = this.store(dynamic_content.key + entryid + '_locales');
       locale_id = io.getIdFromLocale(zd_locale);
       data = {
         variant: {
@@ -154,13 +154,17 @@ var dynamic_content = module.exports = {
           locale_id: locale_id
         }
       };
+      var entry = _.findWhere(
+        this.store(dynamic_content.key)[dynamic_content.api],
+        {'id': entryid}
+      );
       if (_.contains(existing_locales, zd_locale)) {
         variant = _.find(entry.variants, function(v){
           return v.locale_id == locale_id;
         });
-        this.ajax('variantUpdate', data, entry.id, zd_locale, variant.id);
+        this.ajax('variantUpdate', data, entryid, zd_locale, variant.id);
       } else {
-        this.ajax('variantInsert', data, entry.id, zd_locale);
+        this.ajax('variantInsert', data, entryid, zd_locale);
       }
     },
 

--- a/src/lib/zendesk-api/factory.js
+++ b/src/lib/zendesk-api/factory.js
@@ -322,18 +322,18 @@ module.exports = function(name, key, api) {
         io.pushSync('brandLocales_' + brand_url);
         this.ajax('zdGetBrandLocales', brand_url);
       },
-      'zdUpsert<T>Translation': function(resource_data, entry, zdLocale) {
-        logger.info(M('Upsert <T> with Id:') + entry.id + 'and locale:' + zdLocale);
+      'zdUpsert<T>Translation': function(resource_data, entryid, zdLocale) {
+        logger.info(M('Upsert <T> with Id:') + entryid + 'and locale:' + zdLocale);
         var translationData = common.translationObjectFormat(this.$, resource_data, zdLocale, key);
 
-        var existing_locales = this.store(factory.key + entry.id + '_locales');
+        var existing_locales = this.store(factory.key + entryid + '_locales');
         var checkLocaleExists = _.any(existing_locales, function(l){
           return l == zdLocale;
         });
         if (checkLocaleExists) {
-          this.ajax(M('zd<T>Update'), translationData, entry.id, zdLocale);
+          this.ajax(M('zd<T>Update'), translationData, entryid, zdLocale);
         } else {
-          this.ajax(M('zd<T>Insert'), translationData, entry.id, zdLocale);
+          this.ajax(M('zd<T>Insert'), translationData, entryid, zdLocale);
         }
       },
       'asyncGetZd<T>Translations': function(id) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
   "defaultLocale": "en",
   "private": false,
   "location": "nav_bar",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "frameworkVersion": "1.0",
   "parameters": [
     {

--- a/src/templates/sync_page.hdbs
+++ b/src/templates/sync_page.hdbs
@@ -347,7 +347,7 @@
   {{#if dataset.pagination_visible}}
     <div class="o-pagination u-marginBottom-3x">
     {{#if dataset.page_prev_enabled}}
-        <a class="o-link o-pagination__prev js-{{page}} js-goto-prev" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">&laquo;</a>
+        <a class="o-link o-pagination__prev js-{{page}} js-goto-page" data-type="{{{dataset.type}}}" data-page="{{{dataset.prev_page}}}">&laquo;</a>
     {{/if}}
     {{#unless dataset.page_prev_enabled}}
         <span class="o-pagination__prev is-disabled">&laquo;</span>
@@ -356,7 +356,7 @@
         <a class="o-link o-pagination__page js-{{../page}} js-goto-page" data-type="{{{../dataset.type}}}" data-page="{{{this}}}">{{{this}}}</a>
     {{/each}}
     {{#if dataset.page_next_enabled}}
-        <a class="o-link o-pagination__next js-{{page}} js-goto-next" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">&raquo;</a>
+        <a class="o-link o-pagination__next js-{{page}} js-goto-page" data-type="{{{dataset.type}}}" data-page="{{{dataset.next_page}}}">&raquo;</a>
     {{/if}}
     {{#unless dataset.page_next_enabled}}
         <span class="o-pagination__next is-disabled">&raquo;</span>
@@ -368,72 +368,3 @@
   </div>
 
 </div>
-
-
-
-
-
-{{!-- <div class="row-fluid">
-    <div class="span12">
-        <div class="wrapper nowrap">
-            <div class="messagebox">
-                <p><span class="message sync-message"></span></p>
-                <p>
-                    <span class="txh3 plain type_name">Articles</span><span>Switch to:</span>
-                    <span class="buttonized bluebtn btn-border disabled enable_column page_action_articles">Articles</span>
-                    <a page-action="section" class="buttonized bluebtn btn-border enable_column page_action_sections">Sections</a>
-                    <a page-action="categories" class="buttonized bluebtn btn-border enable_column page_action_categories">Categories</a>
-                    <span class="per-page-btn">Per Page:
-    <a id="perpage-ten" class="buttonized bluebtn btn-border enable_column page_action_per_page_ten">10</a>
-    <a id="perpage-twenty" class="buttonized bluebtn btn-border enable_column page_action_per_page_twenty">20</a>
-    </p>
-                <p><span>Sort By:</span>
-                    <a id="sortby-title" class="buttonized bluebtn btn-border enable_column js-sortby-title">Title</a>
-                    <a id="sortby-last-updated" class="buttonized bluebtn btn-border enable_column js-sortby-updated_at">Last Updated</a>
-                    <span class="batch-upload-btn"><a id="batch-upload" class="buttonized bluebtn btn-border enable_column js-batch-upload" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">Batch Upload</a></span>
-                    <span class="batch-download-btn"><a id="batch-download" class="buttonized bluebtn btn-border enable_column js-batch-download" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">Batch Download</a></span>
-                    <span class="sync-btn"><a class="buttonized bluebtn btn-border enable_column js-refresh" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">Sync</a></span>
-                </p>
-                <!-- TODO a class="buttonized bluebtn btn-border enable_column page_action_search">Search</a-->
-                </span>
-                </p>
-
-            </div>
-            <table data-toggle="table" data-url="data1.json" data-cache="false" data-height="299">
-                <thead>
-                    <tr class="table_top">
-                        <th class="enable_column" style="min-width: 300px;">Resource</th>
-                        <th class="enable_column" style="min-width: 80px;">Last</br>Updated</th>
-                        <th class="enable_column" style="min-width: 80px;">Upload</br>Content</br>to Transifex</th>
-                        <th class="enable_column" style="min-width: 80px;">Download</br>Translations</br>to Zendesk</th>
-                        <th class="enable_column" style="min-width: 120px;">Completed</br>Locales</th>
-                    </tr>
-                </thead>
-                <tbody>
-
-                </tbody>
-            </table>
-            {{#if dataset.pagination_visible}}
-                <div class="pagination">
-                    <ul>
-                        {{#if dataset.page_prev_enabled}}
-                            <li><a id="page-prev" class="js-goto-prev" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">&laquo;</a></li>
-                        {{/if}}
-                        {{#unless dataset.page_prev_enabled}}
-                            <li class="is-disabled"><a>&laquo;</a></li>
-                        {{/unless}}
-                        {{#each dataset.pages}}
-                            <li><a id="page-{{{this}}}" class="js-goto-page" data-type="{{{../dataset.type}}}" data-page="{{{this}}}">{{{this}}}</a></li>
-                        {{/each}}
-                        {{#if dataset.page_next_enabled}}
-                            <li><a id="page-next" class="js-goto-next" data-type="{{{dataset.type}}}" data-current-page="{{{dataset.current_page}}}">&raquo;</a></li>
-                        {{/if}}
-                        {{#unless dataset.page_next_enabled}}
-                            <li class="is-disabled"><a>&raquo;</a></li>
-                        {{/unless}}
-                    </ul>
-                </div>
-            {{/if}}
-        </div>
-    </div>
-</div> --}}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5,6 +5,34 @@
       "value": "Translate your Zendesk Help Center",
       "title": "Translate your Zendesk Help Center"
     },
+    "long_description": "
+With Transifex and Transifex Sync, you can store all your translatable content, work with translators, and track the progress of your translations from a central place. There’s no need to copy and paste translations into your Help Center or send any files around. And it even works for multiple brands in Zendesk.
+
+Here’s how Transifex Sync works:
+
+* Push articles, section titles, category titles, and dynamic content from Zendesk to Transifex for translation.
+* Translate with the help of your translation agency, conveniently order translations from a variety of translation providers, or crowdsource your translations.
+* Pull finished translations back into Zendesk.
+
+Ready to get started? Install Transifex Sync and head over to the [Transifex website](https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) to start a trial. From here, you’ll be able to connect your Zendesk Help Center with a specific project to start translating!
+",
+    "installation_instructions": "Before installing Transifex Sync, [please sign up](href="https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) for a Transifex account if you don’t have one already. Then create a new project within Transifex to store all your content. For the complete instructions on creating a project, visit the [Transifex Sync documentation](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd).
+
+    Once you’ve created a project, log in to your Zendesk Agent and navigate to the Admin section (look for the gear icon in the bottom left). Select Marketplace from the menu, then search for \"Transifex Sync\".
+
+    From the search results, click the Transifex Sync app icon. Hit Install App to begin the installation process.
+
+    Next, configure your Transifex Sync app settings:
+
+    * Title: Name for the application.
+    * Transifex Username
+    * Transifex Password: As an alternative to using your username and password, you can [use an API key](https://docs.transifex.com/api/introduction#authentication).
+    * Transifex Project URL: To get the project’s URL, go to your Dashboard, select the project, and click on the name of the project. Then copy and paste the whole URL into this field. It should look something like this: https://www.transifex.com/Organization-Slug/Project-Slug/.
+    * Zendesk API Key: If you plan to translate multiple brands, [generate an API token](https://support.zendesk.com/hc/en-us/articles/226022787) and paste it in this field. If you’re only translating a single brand, no need to put anything in.
+    * Enable Role Restrictions: Select which users within Zendesk should have access to this app.
+    Click Install and you’re done! At any time, you can access the Transifex Sync app by clicking the Tx icon in the sidebar.
+
+    For more information on using Transifex Sync, please refer to the documentation [here](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd)."
     "name": {
       "value": "Transifex Sync",
       "title": "Transifex Sync"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5,34 +5,8 @@
       "value": "Translate your Zendesk Help Center",
       "title": "Translate your Zendesk Help Center"
     },
-    "long_description": "
-With Transifex and Transifex Sync, you can store all your translatable content, work with translators, and track the progress of your translations from a central place. There’s no need to copy and paste translations into your Help Center or send any files around. And it even works for multiple brands in Zendesk.
-
-Here’s how Transifex Sync works:
-
-* Push articles, section titles, category titles, and dynamic content from Zendesk to Transifex for translation.
-* Translate with the help of your translation agency, conveniently order translations from a variety of translation providers, or crowdsource your translations.
-* Pull finished translations back into Zendesk.
-
-Ready to get started? Install Transifex Sync and head over to the [Transifex website](https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) to start a trial. From here, you’ll be able to connect your Zendesk Help Center with a specific project to start translating!
-",
-    "installation_instructions": "Before installing Transifex Sync, [please sign up](href="https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) for a Transifex account if you don’t have one already. Then create a new project within Transifex to store all your content. For the complete instructions on creating a project, visit the [Transifex Sync documentation](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd).
-
-    Once you’ve created a project, log in to your Zendesk Agent and navigate to the Admin section (look for the gear icon in the bottom left). Select Marketplace from the menu, then search for \"Transifex Sync\".
-
-    From the search results, click the Transifex Sync app icon. Hit Install App to begin the installation process.
-
-    Next, configure your Transifex Sync app settings:
-
-    * Title: Name for the application.
-    * Transifex Username
-    * Transifex Password: As an alternative to using your username and password, you can [use an API key](https://docs.transifex.com/api/introduction#authentication).
-    * Transifex Project URL: To get the project’s URL, go to your Dashboard, select the project, and click on the name of the project. Then copy and paste the whole URL into this field. It should look something like this: https://www.transifex.com/Organization-Slug/Project-Slug/.
-    * Zendesk API Key: If you plan to translate multiple brands, [generate an API token](https://support.zendesk.com/hc/en-us/articles/226022787) and paste it in this field. If you’re only translating a single brand, no need to put anything in.
-    * Enable Role Restrictions: Select which users within Zendesk should have access to this app.
-    Click Install and you’re done! At any time, you can access the Transifex Sync app by clicking the Tx icon in the sidebar.
-
-    For more information on using Transifex Sync, please refer to the documentation [here](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd)."
+    "long_description": "With Transifex and Transifex Sync, you can store all your translatable content, work with translators, and track the progress of your translations from a central place. There’s no need to copy and paste translations into your Help Center or send any files around. And it even works for multiple brands in Zendesk.\n\nHere’s how Transifex Sync works:\n\n* Push articles, section titles, category titles, and dynamic content from Zendesk to Transifex for translation.\n* Translate with the help of your translation agency, conveniently order translations from a variety of translation providers, or crowdsource your translations.\n* Pull finished translations back into Zendesk.\n\nReady to get started? Install Transifex Sync and head over to the [Transifex website](https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) to start a trial. From here, you’ll be able to connect your Zendesk Help Center with a specific project to start translating!",
+    "installation_instructions": "Before installing Transifex Sync, [please sign up](https://www.transifex.com/signup/?utm_source=zd-marketplace&amp;utm_campaign=int-zd) for a Transifex account if you don’t have one already. Then create a new project within Transifex to store all your content. For the complete instructions on creating a project, visit the [Transifex Sync documentation](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd).\n\nOnce you’ve created a project, log in to your Zendesk Agent and navigate to the Admin section (look for the gear icon in the bottom left). Select Marketplace from the menu, then search for \"Transifex Sync\".\n\nFrom the search results, click the Transifex Sync app icon. Hit Install App to begin the installation process.\n\nNext, configure your Transifex Sync app settings:\n\n* Title: Name for the application.\n* Transifex Username\n* Transifex Password: As an alternative to using your username and password, you can [use an API key](https://docs.transifex.com/api/introduction#authentication).\n* Transifex Project URL: To get the project’s URL, go to your Dashboard, select the project, and click on the name of the project. Then copy and paste the whole URL into this field. It should look something like this: https://www.transifex.com/Organization-Slug/Project-Slug/.\n* Zendesk API Key: If you plan to translate multiple brands, [generate an API token](https://support.zendesk.com/hc/en-us/articles/226022787) and paste it in this field. If you’re only translating a single brand, no need to put anything in.\n* Enable Role Restrictions: Select which users within Zendesk should have access to this app.\n\nClick Install and you’re done! At any time, you can access the Transifex Sync app by clicking the Tx icon in the sidebar.\n\nFor more information on using Transifex Sync, please refer to the documentation [here](http://docs.transifex.com/integrations/zendesk/?utm_source=zd-marketplace&amp;utm_campaign=int-zd).",
     "name": {
       "value": "Transifex Sync",
       "title": "Transifex Sync"


### PR DESCRIPTION
The previous behaviour of the parser is that upon loading a page it will fetch all 100% translated content and store it to local storage (this.store is a function of the zendesk framework that does exactly that). When we want to upload translations to zendesk we just pick them from local storage. This has the disadvantage that we occupy huge ammount of local storage, many times for no reason. With this PR the translations from transifex will be fetched on demand only for the resources that have been selected for syncing and they won't be stored to local storage. 

Also I have simplified a bit the pagination.

@codegaze if you could take a look, pls! We can go over it together if you prefer.