### PR TITLE
TX-9274: Fix create project bug

### DIFF
--- a/src/javascripts/transifex-api/project.js
+++ b/src/javascripts/transifex-api/project.js
@@ -191,11 +191,11 @@ var project = module.exports = {
         })
 
       Promise.all(promises).then((results) => {
-        that.languagesComplete(true);
+        that.languagesComplete(true, slug);
       })
       .catch(err => {
         // Receives first rejection among the Promises
-        that.languagesComplete(false);
+        that.languagesComplete(false, slug);
       });
 
       this.store('brands', _.map(brands, function(brand) {
@@ -204,7 +204,7 @@ var project = module.exports = {
       }));
       this.uiArticlesBrandTab(brand_id);
     },
-    languagesComplete: function (success) {
+    languagesComplete: function (success, slug) {
       // Inform the user about the newly created resource
       let messages = this.store('messages') || [];
       let msg = '', type = '';
@@ -213,7 +213,11 @@ var project = module.exports = {
         msg = 'All languages were successfully added to project';
         type = 'success';
       } else {
-        msg = 'Failed to add languages to the newly created project';
+        let project_link = this.tx.concat('/', this.organization,
+                                          '/', slug, '/languages/');
+        msg = 'Some languages failed to be added to project.' +
+          ' You can go to <a href="' + project_link + '">the project page</a>' +
+          ' to add / remove target languages.';
         type = 'warning';
       }
 

--- a/src/javascripts/ui/notifications.js
+++ b/src/javascripts/ui/notifications.js
@@ -20,7 +20,7 @@ module.exports = {
       let msg = $('[data-notification="' + type + '"]').clone(false);
       // Make notification visible and mark it as removable
       msg.removeClass('u-display-none').addClass('js-notification-temp');
-      msg.find('.js-notification-message').text(message);
+      msg.find('.js-notification-message').html(message);
       msg.find('.js-notification-close').click(this.closeNotification);
       msg.appendTo('.js-notifications');
     },

--- a/src/javascripts/ui/notifications.js
+++ b/src/javascripts/ui/notifications.js
@@ -5,33 +5,27 @@
 import $ from 'jquery';
 
 module.exports = {
-  events: {
-    'click .js-notification-close': 'uiNotificationsClose',
-  },
-  eventHandlers: {
-    uiNotificationsClose: function(event) {
-      if (event) event.preventDefault();
-      $('[data-notification]').addClass('u-display-none');
-    }
-  },
   actionHandlers: {
+    closeNotification: e => $(e.target).parents('[data-notification]').remove(),
     notifySuccess: function(message) {
-      $('[data-notification="warning"], [data-notification="error"]').addClass('u-display-none');
-      $('[data-notification="success"]').removeClass('u-display-none').
-        find('.js-notification-message').text(message);
+      this.notify(message, 'success');
     },
     notifyWarning: function(message) {
-      $('[data-notification="success"], [data-notification="error"]').addClass('u-display-none');
-      $('[data-notification="warning"]').removeClass('u-display-none').
-        find('.js-notification-message').text(message);
+      this.notify(message, 'warning');
     },
     notifyError: function(message) {
-      $('[data-notification="success"], [data-notification="warning"]').addClass('u-display-none');
-      $('[data-notification="error"]').removeClass('u-display-none').
-        find('.js-notification-message').text(message);
+      this.notify(message, 'error');
+    },
+    notify: function(message, type) {
+      let msg = $('[data-notification="' + type + '"]').clone(false);
+      // Make notification visible and mark it as removable
+      msg.removeClass('u-display-none').addClass('js-notification-temp');
+      msg.find('.js-notification-message').text(message);
+      msg.find('.js-notification-close').click(this.closeNotification);
+      msg.appendTo('.js-notifications');
     },
     notifyReset: function() {
-      this.uiNotificationsClose();
+      $('.js-notification-temp').remove();
     }
   },
 };

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -204,6 +204,13 @@ module.exports = function(T, t, api) {
         $('[data-toggle="tooltip"]').tooltip({
           container: 'body',
         });
+
+        let messages = this.store('messages') || [];
+        _.each(messages, notification =>
+          this.notify(notification['message'], notification['type'])
+        );
+        // Empty the messages queue
+        this.store('messages', []);
       },
       'ui<T>BatchUpload': function(event) {
         if (event) event.preventDefault();


### PR DESCRIPTION
Related to [TX-9274: When I add a new brand, I get stuck with a loader if the languages groups were not created](https://transifex.atlassian.net/browse/TX-9274).

Fixed by correctly handling the outcome of each request that creates language groups to a project. Once all requests complete, we display a notification to the user about the outcome. Refactor the notifications, in order to be able to display more than one at the same time.