### PR TITLE
TX-9231: Automatically rename resources in Transifex

### DIFF
--- a/src/javascripts/io.js
+++ b/src/javascripts/io.js
@@ -17,7 +17,11 @@ var SETTINGS = {},
     ZD_LOCALES = {},
     RESOURCE_ARRAY = [],
     ZD_USER_EMAIL = '',
-    QUERY = '';
+    QUERY = '',
+    RENAMES = {
+      done: 0,
+      failed: 0,
+    };
 
 module.exports = {
   setSettings: settings => {
@@ -87,5 +91,19 @@ module.exports = {
   getQuery: () => QUERY,
   setQuery: q => {
     QUERY = q;
+  },
+
+  renameDone: () => {
+    RENAMES['done']++;
+  },
+  renameFailed: () => {
+    RENAMES['failed']++;
+  },
+  getRenames: () => RENAMES,
+  clearRenames: () => {
+    RENAMES = {
+      done: 0,
+      failed: 0,
+    };
   },
 };

--- a/src/javascripts/transifex-api/project.js
+++ b/src/javascripts/transifex-api/project.js
@@ -174,14 +174,8 @@ var project = module.exports = {
       this.store('brands', brands);
 
       // Inform the user about the newly created resource
-      let messages = this.store('messages') || [];
       let msg = 'Project ' + slug + ' created';
-      messages.push({
-        type: 'success',
-        message: msg,
-      });
-      logger.info('Message added: [SUCCESS] ' + msg);
-      this.store('messages', messages);
+      this.queueNotification(msg, 'success');
 
       // Try to create language groups
       let total = targets.length, succeeded = 0, failed = 0;

--- a/src/javascripts/transifex-api/project.js
+++ b/src/javascripts/transifex-api/project.js
@@ -127,10 +127,7 @@ var project = module.exports = {
     txProjectDone: function(data, status) {
       logger.info('Transifex Project Retrieved with status:', status);
       this.store(project.key, data);
-      var resource_array = _.map(data.resources, function(resource) {
-        return resource.slug;
-      });
-      io.setResourceArray(resource_array);
+      io.setResourceArray(data.resources);
       io.popSync(project.key);
       this.checkAsyncComplete();
     },

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -10,6 +10,8 @@ var txProject = require('./project'),
     logger = require('../logger'),
     txutils = require('../txUtil');
 
+const findIndex = require('lodash.findindex');
+
 var resource = module.exports = {
   // selfies
   key: 'tx_resource',
@@ -64,6 +66,18 @@ var resource = module.exports = {
       logger.debug('txUpdateResource ajax request:', data + '||' + resourceName + '||' + data.i18n_type);
       return {
         url: this.tx + '/api/2/project/' + this.selected_brand.tx_project + '/resource/' + resourceName + '/content/',
+        type: 'PUT',
+        headers: resource.headers,
+        data: JSON.stringify(data),
+        cache: false,
+        contentType: 'application/json',
+        cors: true
+      };
+    },
+    txRenameResource: function(data, resourceSlug) {
+      logger.debug('txRenameResource ajax request:', data + '||' + resourceSlug);
+      return {
+        url: this.tx + '/api/2/project/' + this.selected_brand.tx_project + '/resource/' + resourceSlug + '/',
         type: 'PUT',
         headers: resource.headers,
         data: JSON.stringify(data),
@@ -155,6 +169,16 @@ var resource = module.exports = {
       io.opSet(resourceName, 'fail');
       this.checkAsyncComplete();
     },
+
+    txRenameResourceDone: function(data, resourceSlug) {
+      logger.info('Transifex resource renamed with status:', 'OK');
+      this.notifySuccess('Resource ' + resourceSlug + ' name updated');
+    },
+
+    txRenameResourceError: function(jqXHR, resourceSlug) {
+      logger.info('Transifex Resource Retrieved with status:', jqXHR.statusText);
+      this.notifyError('Failed to update resource ' + resourceSlug + ' name');
+    },
   },
   actionHandlers: {
     completedLanguages: function(stats) {
@@ -173,11 +197,19 @@ var resource = module.exports = {
     },
     txUpsertResource: function(content, slug) {
       logger.info('txUpsertResource:', content + '||' + slug);
-      var project = this.store(txProject.key);
-      var resources = io.getResourceArray();
-      //check list of resources in the project
+      // Check list of resources in the Transifex project
+      let project = this.store(txProject.key);
+      let resources = io.getResourceArray();
       io.opSet(slug, 'processing');
-      if (syncUtil.isStringinArray(slug, resources)) {
+      let resource_index = findIndex(resources, {slug: slug});
+      if (resource_index > -1) {
+        let new_name = content.name,
+            old_name = resources[resource_index]['name'];
+        if (new_name != old_name) {
+          this.ajax('txRenameResource', {"name": new_name}, slug)
+            .done(data => this.txRenameResourceDone(data, slug))
+            .fail(xhr => this.txRenameResourceError(xhr, slug));
+        }
         this.ajax('txUpdateResource', content, slug)
           .done(data => this.txUpdateResourceDone(data, slug))
           .fail(xhr => this.txUpsertResourceError(xhr, slug));

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -172,12 +172,12 @@ var resource = module.exports = {
 
     txRenameResourceDone: function(data, resourceSlug) {
       logger.info('Transifex resource renamed with status:', 'OK');
-      this.notifySuccess('Resource ' + resourceSlug + ' name updated');
+      io.renameDone();
     },
 
     txRenameResourceError: function(jqXHR, resourceSlug) {
       logger.info('Transifex Resource Retrieved with status:', jqXHR.statusText);
-      this.notifyError('Failed to update resource ' + resourceSlug + ' name');
+      io.renameFail();
     },
   },
   actionHandlers: {
@@ -209,6 +209,11 @@ var resource = module.exports = {
           this.ajax('txRenameResource', {"name": new_name}, slug)
             .done(data => this.txRenameResourceDone(data, slug))
             .fail(xhr => this.txRenameResourceError(xhr, slug));
+
+          // Save the new name to the resources array so we won't try to rename
+          // the same resource twice
+          resources[resource_index]['name'] = new_name;
+          io.setResourceArray(resources);
         }
         this.ajax('txUpdateResource', content, slug)
           .done(data => this.txUpdateResourceDone(data, slug))

--- a/src/javascripts/ui/notifications.js
+++ b/src/javascripts/ui/notifications.js
@@ -4,9 +4,11 @@
  */
 import $ from 'jquery';
 
+const logger = require('../logger')
+
 module.exports = {
   actionHandlers: {
-    closeNotification: e => $(e.target).parents('[data-notification]').remove(),
+    closeNotification: e => $(e.target).parents('.js-notification-temp').remove(),
     notifySuccess: function(message) {
       this.notify(message, 'success');
     },
@@ -18,6 +20,7 @@ module.exports = {
     },
     notify: function(message, type) {
       let msg = $('[data-notification="' + type + '"]').clone(false);
+      msg.removeAttr('data-notification');
       // Make notification visible and mark it as removable
       msg.removeClass('u-display-none').addClass('js-notification-temp');
       msg.find('.js-notification-message').html(message);
@@ -26,6 +29,23 @@ module.exports = {
     },
     notifyReset: function() {
       $('.js-notification-temp').remove();
-    }
+    },
+    queueNotification: function(message, type) {
+      let messages = this.store('messages') || [];
+      messages.push({
+        type: type,
+        message: message,
+      });
+      logger.info('Message queued: [' + type + '] ' + message);
+      this.store('messages', messages);
+    },
+    displayQueuedNotifications: function() {
+      let messages = this.store('messages') || [];
+      _.each(messages, notification =>
+        this.notify(notification['message'], notification['type'])
+      );
+      // Empty the messages queue
+      this.store('messages', []);
+    },
   },
 };

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -205,12 +205,7 @@ module.exports = function(T, t, api) {
           container: 'body',
         });
 
-        let messages = this.store('messages') || [];
-        _.each(messages, notification =>
-          this.notify(notification['message'], notification['type'])
-        );
-        // Empty the messages queue
-        this.store('messages', []);
+        this.displayQueuedNotifications();
       },
       'ui<T>BatchUpload': function(event) {
         if (event) event.preventDefault();

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -328,6 +328,16 @@ module.exports = function(T, t, api) {
           this.notifyWarning((total - failed) + ' ' + content_type + ' were successfully uploaded to Transifex, ' + failed + ' ' + api + ' could not be uploaded.');
           $('[data-resource] .o-status[data-item="controller"]:not(.is-success)').addClass('is-warning');
         }
+
+        // Display any possible information about resource renaming
+        let renames = io.getRenames();
+        if (renames['done'] > 0) {
+          this.notifySuccess(renames['done'] + ' resources renamed in Transifex');
+        }
+        if (renames['fail'] > 0) {
+          this.notifyWarning(renames['fail'] + ' resources failed to be renamed in Transifex');
+        }
+        io.clearRenames();
       },
       'ui<T>DownloadComplete': function() {
         var that = this;


### PR DESCRIPTION
Extend the Transifex API utilities to include resource renaming. When a Zendesk's entry name is changed, we perform an extra request to rename the corresponding Transifex resource.

Related to [TX-9231: When I rename an article in Zendesk, I want the corresponding resource in Transifex to be renamed, so I can find the resource easily](https://transifex.atlassian.net/browse/TX-9231)