### PR TITLE
Improve articles upsert operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dist/assets/main.js
 dist/assets/main.js.map
 dist/translations/
 dist/tmp/
+dist/.zat
 
 # Users Environment Variables
 .lock-wscript

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -200,13 +200,15 @@ var resource = module.exports = {
 
       return arr;
     },
-    txUpsertBatchResources: function(category, batchArray) {
+    txUpsertBatchResources: function(getTForTranslationFunction, category, batchArray) {
       /**
        * Upsert multiple resources
        * 
+       * @param {function} getTForTranslationFunction Reference to the get<T>ForTranslation function
        * @param {string} category Possible values: 'Resources' | 'Dynamic'
        * @param {list} batchArray An array of resources to be upserted
        */
+      resource.getTForTranslationFunction = getTForTranslationFunction
       resource.batchArray = batchArray;
       resource.category = category;
       /*
@@ -235,7 +237,7 @@ var resource = module.exports = {
       // The getArticlesForTranslation() can be found in factory.js as 
       // get<T>ForTranslation(). In our case, <T> is Articles.
       let resource_request = common.txRequestFormat(
-        this.getArticlesForTranslation(entry), resource.category
+        resource.getTForTranslationFunction(entry), resource.category
       );
       io.pushSync(resource.key + txResourceName + 'upsert');
       this.txUpsertResource(resource_request, txResourceName);

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -228,9 +228,12 @@ var resource = module.exports = {
          * If the array length is empty, no other resources left to be upserted, so at
          * this point we can notify the frontend.
          */
+          this.notifyReset();
           this.checkAsyncComplete();
           return;
       }
+      this.notifyReset();
+      this.notifyInfo('' + resource.batchArray.length + ' resources remaining');
       // Get the next resource to upsert
       let entry = resource.batchArray.shift();
       let txResourceName = entry.resource_name;

--- a/src/javascripts/ui/notifications.js
+++ b/src/javascripts/ui/notifications.js
@@ -18,6 +18,9 @@ module.exports = {
     notifyError: function(message) {
       this.notify(message, 'error');
     },
+    notifyInfo: function(message) {
+      this.notify(message, 'info');
+    },
     notify: function(message, type) {
       let msg = $('[data-notification="' + type + '"]').clone(false);
       msg.removeAttr('data-notification');

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -232,13 +232,7 @@ module.exports = function(T, t, api) {
         this[M('start<T>Process')]('upload');
         io.opResetAll();
         this.loadSyncPage = this[M('ui<T>UpsertComplete')];
-        for (var i = 0; i < objects.length; i++) {
-          entry = objects[i];
-          txResourceName = entry.resource_name;
-          resource_request = common.txRequestFormat(this[M('get<T>ForTranslation')](entry), category);
-          io.pushSync(txResource.key + txResourceName + 'upsert');
-          this.txUpsertResource(resource_request, txResourceName);
-        }
+        this.txUpsertBatchResources(category, objects);
       },
       'ui<T>BatchDownload': function(event) {
         if (event) event.preventDefault();

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -232,7 +232,7 @@ module.exports = function(T, t, api) {
         this[M('start<T>Process')]('upload');
         io.opResetAll();
         this.loadSyncPage = this[M('ui<T>UpsertComplete')];
-        this.txUpsertBatchResources(category, objects);
+        this.txUpsertBatchResources(this[M('get<T>ForTranslation')], category, objects);
       },
       'ui<T>BatchDownload': function(event) {
         if (event) event.preventDefault();

--- a/src/stylesheets/components.scss
+++ b/src/stylesheets/components.scss
@@ -76,6 +76,10 @@
   &--error { border-color: $status-error-color; }
   &--error .c-system-message__symbol { fill: $status-error-color; }
 
+  &--info { border-color: $status-information-color; }
+  &--info .c-system-message__symbol { fill: $status-information-color; }
+  &--info .c-system-message__title { color: $status-information-color; }
+
   &__content {
     position: relative;
     flex: 1 0 0%;
@@ -110,6 +114,11 @@
     &:hover {
       opacity: 0.8;
     }
+  }
+
+  &__title {
+    font-weight: bold;
+    margin-bottom: $baseline-grid;
   }
 
   &__svgFill {

--- a/src/templates/sync_page.hdbs
+++ b/src/templates/sync_page.hdbs
@@ -179,6 +179,23 @@
         </a>
       </div>
 
+      <div class="c-system-message c-system-message--compact c-system-message--info u-display-none" data-notification="info">
+        <svg class="c-system-message__symbol" viewBox="0 0 16 16">
+            <path d="M8 0c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zM8 14.4c-3.5 0-6.4-2.9-6.4-6.4s2.9-6.4 6.4-6.4 6.4 2.9 6.4 6.4c0 3.5-2.9 6.4-6.4 6.4z"></path>
+            <path d="M7.2 7.4v4.2h1.6v-4.2z"></path>
+            <path d="M8.8 5.2c0 0.442-0.358 0.8-0.8 0.8s-0.8-0.358-0.8-0.8c0-0.442 0.358-0.8 0.8-0.8s0.8 0.358 0.8 0.8z"></path>
+        </svg>
+        <div>
+          <div class="c-system-message__title">Uploading files to Transifex</div>
+          <div class="c-system-message__content js-notification-message"></div>
+        </div>
+        <a href="#" class="c-system-message__close js-notification-close">
+          <svg class="u-box-100" viewBox="0 0 16 16">
+            <path class="path1" d="M8 5.905l-5.905-5.714-2.095 2.095 5.714 5.905-5.333 5.333 2.095 2.286 5.524-5.524 5.524 5.524 2.095-2.286-5.524-5.333 5.905-5.905-2.286-2.095-5.714 5.714z"></path>
+          </svg>
+        </a>
+      </div>
+
     </div>
 
     <!-- Header: List header -->


### PR DESCRIPTION
Currently we push resources to Transifex all at once, which causes issues if the resources are too many or if the articles themselves contain too much content.

This happens because browsers allow certain HTTP slots to take place at once (https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#waterfall), blocking the rest until one of those slots is available again. If those calls take too long to return a response (eg. if parsing takes too long or are just too many) the rest of the calls get timeout out.

In order to solve this, we push resources one at a time, uploading the next one only when the previous one has been completed. This will make uploading articles slower but it will ensure that none will timeout due to too many requests being blocked from the browser itself.