### PR TITLE
Avoid using percentages for completion detection

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -12,7 +12,7 @@
       "nav_bar": "assets/index.html"
     }
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "frameworkVersion": "2.0",
   "parameters": [
     {

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -191,7 +191,7 @@ var resource = module.exports = {
           locales = io.getLocales(),
           default_locale = this.store('default_locale');
       _.each(stats, function(value, key) {
-        var match = (value['completed'] === "100%");
+        var match = (value['untranslated_entities'] == 0);
         var zd_key = syncUtil.txLocaletoZd(key, locales);
         if (match && zd_key && zd_key !== default_locale) {
           arr.push(key);


### PR DESCRIPTION
Detect the completed languages based on the untranslated entities instead of the translation percentage. This will avoid reporting wrong languages as completed because of the rounding in percentages. A language will be considered completed once it has no untranslated entities.