### PR TITLE
Pull translations from Transifex using queues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,32 @@
 {
   "name": "transifex-sync-zendesk",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Sync translations between Zendesk Help Center and Transifex",
   "main": "dist/app.js",
-  "scripts": {
-    "test": "gulp",
-    "lint": "gulp lint",
-    "test-browser": "gulp test-browser",
-    "watch": "gulp watch",
-    "build": "gulp build",
-    "coverage": "gulp coverage"
-  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/matthewjackowski/custard-moon.git"
+    "url": "https://github.com/transifex/transifex-sync-zendesk/"
   },
   "keywords": [],
   "author": "Matthew Jackowski <mattjjacko@gmail.com>",
+  "contributors": [
+    "Sofia Margariti <sofia@transifex.com>",
+    "Matthew Jackowski <mattjjacko@gmail.com>",
+    "Alex Psi <alexpsi256@gmail.com>",
+    "Rigas Papathanasopoulos <rigas@transifex.com>",
+    "Nikos Vasileiou <nikosv@transifex.com>",
+    "Mike Giannakopoulos <mikeg@transifex.com>",
+    "Sofia Margariti <sofiamargariti@hotmail.com>",
+    "Rigas Papathanasopoulos <rigaspapas@gmail.com>",
+    "nsiddarthreddy <nsiddarthreddy@gmail.com>",
+    "Dionysis Tsoumas <diotsoumas@transifex.com>",
+    "samuelchan22 <samuel@transifex.com>",
+    "Samuel Chan <samuel@transifex.com>",
+    "Matthew <matthew@julies-imac.attlocal.net>",
+    "Dennis Tsoumas <diotsoumas@gmail.com>",
+    "NoahTX <noah@transifex.com>",
+    "Diego Búrigo Zacarão <diegobz@transifex.com>"
+  ],
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/transifex/transifex-sync-zendesk/issues"

--- a/src/javascripts/transifex-api/project.js
+++ b/src/javascripts/transifex-api/project.js
@@ -15,7 +15,7 @@ var project = module.exports = {
   key: 'tx_project',
   url: '',
   headers: {
-    'X-Source-Zendesk': 'ZendeskApp/2.1.0'
+    'X-Source-Zendesk': 'ZendeskApp/3.0.2'
   },
   username: '',
   password: '',

--- a/src/javascripts/transifex-api/resource.js
+++ b/src/javascripts/transifex-api/resource.js
@@ -19,7 +19,7 @@ var resource = module.exports = {
   url: '',
   inserturl: '',
   headers: {
-    'X-Source-Zendesk': 'ZendeskApp/3.0.0'
+    'X-Source-Zendesk': 'ZendeskApp/3.0.2'
   },
   username: '',
   password: '',

--- a/src/javascripts/ui/sync-factory.js
+++ b/src/javascripts/ui/sync-factory.js
@@ -254,17 +254,7 @@ module.exports = function(T, t, api) {
         this[M('start<T>Process')]('download');
         io.opResetAll();
         this.loadSyncPage = this[M('ui<T>DownloadComplete')];
-
-        for (var i = 0; i < objects.length; i++) {
-          entry = objects[i];
-          txResourceName = entry.resource_name;
-          resource = this.store(txResource.key + txResourceName);
-          completedLocales = this.completedLanguages(resource);
-
-          for (var ii = 0; ii < completedLocales.length; ii++) { // iterate through list of locales
-            this.asyncGetTxResource(txResourceName, completedLocales[ii], entry.id);
-          }
-        }
+        this.zdUpsertBatchTranslations(objects);
       },
       'uiSync': function() {
         if (this.processing) return;
@@ -336,6 +326,7 @@ module.exports = function(T, t, api) {
       'ui<T>DownloadComplete': function() {
         var that = this;
         logger.debug('Download complete');
+        this.notifyReset();
         this[M('end<T>Process')]();
         var resource_prefix = io.getFeature('html-tx-resource') ? 'HTML-' : '';
         var total = 0, failed = 0;

--- a/src/templates/sync_page.hdbs
+++ b/src/templates/sync_page.hdbs
@@ -186,7 +186,7 @@
             <path d="M8.8 5.2c0 0.442-0.358 0.8-0.8 0.8s-0.8-0.358-0.8-0.8c0-0.442 0.358-0.8 0.8-0.8s0.8 0.358 0.8 0.8z"></path>
         </svg>
         <div>
-          <div class="c-system-message__title">Uploading files to Transifex</div>
+          <div class="c-system-message__title">Syncing contents with Transifex</div>
           <div class="c-system-message__content js-notification-message"></div>
         </div>
         <a href="#" class="c-system-message__close js-notification-close">


### PR DESCRIPTION
Instead of firing up a set of requests in parallel, we will now use a queue to pull translations from Transifex, exactly the same we do when pushing content. This way, we will no longer abuse the network's bandwidth and we will provide an improved UX by informing the user about the syncing progress.