### PR TITLE
Fix custom languages not retrieving trans

### DIFF
--- a/src/javascripts/zendesk-api/config.js
+++ b/src/javascripts/zendesk-api/config.js
@@ -10,7 +10,7 @@ var config = module.exports = {
     activatedLocales: function() {
       logger.debug('Retrieving activated locales for account');
       return {
-        url: config.base_url + 'locales/public.json',
+        url: config.base_url + 'locales.json',
         type: 'GET',
         dataType: 'json',
       };


### PR DESCRIPTION
Problem and/or solution
-----------------------
Problem: when user declares in zendesk non standard locales, their respective translations are not beign fetched from TX
Solution: get the zendesk locales from api/v2/locales.json instead of getting them from api/v2/locales/public.json

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit
